### PR TITLE
feat(custom tabs): add Rich Editor & Markdown Editor support

### DIFF
--- a/src/Enums/TypeFieldEnum.php
+++ b/src/Enums/TypeFieldEnum.php
@@ -14,4 +14,5 @@ enum TypeFieldEnum: string
     case Textarea = 'textarea';
     case Datetime = 'datetime';
     case RichEditor = 'rich_editor';
+    case MarkdownEditor = 'markdown_editor';
 }

--- a/src/Enums/TypeFieldEnum.php
+++ b/src/Enums/TypeFieldEnum.php
@@ -13,4 +13,5 @@ enum TypeFieldEnum: string
     case Select = 'select';
     case Textarea = 'textarea';
     case Datetime = 'datetime';
+    case RichEditor = 'rich_editor';
 }

--- a/src/Forms/CustomForms.php
+++ b/src/Forms/CustomForms.php
@@ -4,6 +4,7 @@ namespace Joaopaulolndev\FilamentGeneralSettings\Forms;
 
 use Filament\Forms\Components\Checkbox;
 use Filament\Forms\Components\DateTimePicker;
+use Filament\Forms\Components\MarkdownEditor;
 use Filament\Forms\Components\RichEditor;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;
@@ -53,6 +54,10 @@ class CustomForms
                     ->seconds($field['seconds']);
             } elseif ($field['type'] === TypeFieldEnum::RichEditor->value) {
                 $fields[] = RichEditor::make($fieldKey)
+                    ->label(__($field['label']))
+                    ->toolbarButtons($field['toolbarButtons'] ?? []);
+            } elseif ($field['type'] === TypeFieldEnum::MarkdownEditor->value) {
+                $fields[] = MarkdownEditor::make($fieldKey)
                     ->label(__($field['label']))
                     ->toolbarButtons($field['toolbarButtons'] ?? []);
             }

--- a/src/Forms/CustomForms.php
+++ b/src/Forms/CustomForms.php
@@ -4,6 +4,7 @@ namespace Joaopaulolndev\FilamentGeneralSettings\Forms;
 
 use Filament\Forms\Components\Checkbox;
 use Filament\Forms\Components\DateTimePicker;
+use Filament\Forms\Components\RichEditor;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
@@ -50,7 +51,12 @@ class CustomForms
                     ->label(__($field['label']))
                     ->placeholder(__($field['placeholder']))
                     ->seconds($field['seconds']);
+            } elseif ($field['type'] === TypeFieldEnum::RichEditor->value) {
+                $fields[] = RichEditor::make($fieldKey)
+                    ->label(__($field['label']))
+                    ->toolbarButtons($field['toolbarButtons'] ?? []);
             }
+
         }
 
         return $fields;

--- a/src/Pages/GeneralSettingsPage.php
+++ b/src/Pages/GeneralSettingsPage.php
@@ -148,7 +148,7 @@ class GeneralSettingsPage extends Page
                 $arrTabs[] = Tabs\Tab::make($customTab['label'])
                     ->label(__($customTab['label']))
                     ->icon($customTab['icon'])
-                    ->schema(CustomForms::get($customTab['fields']))
+                    ->schema($customTab['fields'])
                     ->columns($customTab['columns'])
                     ->statePath('more_configs');
             }


### PR DESCRIPTION
This pull request introduces new editor types and integrates them into the custom forms functionality. The most important changes include the addition of `RichEditor` and `MarkdownEditor` types to the `TypeFieldEnum` enumeration and their corresponding implementations in the `CustomForms` class.

### New Editor Types:

* [`src/Enums/TypeFieldEnum.php`](diffhunk://#diff-77bff5434492890800c527eab519ee695bc59b0d38eacab6347dd311366b99abR16-R17): Added `RichEditor` and `MarkdownEditor` as new cases in the `TypeFieldEnum` enumeration.

### Custom Forms Integration:

* [`src/Forms/CustomForms.php`](diffhunk://#diff-c8a738d2d1430615dbbe07098ef0b941be29d47009810f71ae0564ea3536e157R7-R8): Imported `MarkdownEditor` and `RichEditor` components.
* [`src/Forms/CustomForms.php`](diffhunk://#diff-c8a738d2d1430615dbbe07098ef0b941be29d47009810f71ae0564ea3536e157R55-R64): Updated the `get` method to handle `RichEditor` and `MarkdownEditor` types, including setting labels and toolbar buttons.