### PR TITLE
Add hexColor validation

### DIFF
--- a/src/Forms/ApplicationFieldsForm.php
+++ b/src/Forms/ApplicationFieldsForm.php
@@ -49,6 +49,7 @@ class ApplicationFieldsForm
                 ->prefixIcon('heroicon-o-phone')
                 ->label(__('filament-general-settings::default.support_phone')),
             ColorPicker::make('theme_color')
+                ->hexColor()
                 ->label(__('filament-general-settings::default.theme_color'))
                 ->prefixIcon('heroicon-o-swatch')
                 ->formatStateUsing(fn (?string $state): string => $state ?? config('filament.theme.colors.primary'))


### PR DESCRIPTION
## Pull Request Description

This pull request introduces a minor but important improvement to the `ApplicationFieldsForm` class. Specifically, it enforces hex color formatting in the `ColorPicker` component by adding the `.hexColor()` method.

### Why this change is necessary

Previously, the `ColorPicker` accepted any value, which could lead to invalid or unsupported formats. This lack of validation caused the Theme Builder to fail in some cases. By explicitly requiring hex color values, we ensure consistent formatting and improve the stability and reliability of the Theme Builder.

### Summary of changes

- Updated `ColorPicker` usage to include the `.hexColor()` method.
- Prevents invalid color formats that previously caused Theme Builder issues.
