### PR TITLE
feat(custom tabs): add back Rich Editor support

### DIFF
--- a/src/Enums/TypeFieldEnum.php
+++ b/src/Enums/TypeFieldEnum.php
@@ -15,4 +15,5 @@ enum TypeFieldEnum: string
     case Datetime = 'datetime';
     case Password = 'password';
     case Url = 'url';
+    case RichEditor = 'rich_editor';
 }

--- a/src/Forms/CustomForms.php
+++ b/src/Forms/CustomForms.php
@@ -7,6 +7,7 @@ use Filament\Forms\Components\DateTimePicker;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\RichEditor;
 use Joaopaulolndev\FilamentGeneralSettings\Enums\TypeFieldEnum;
 
 class CustomForms

--- a/src/Forms/CustomForms.php
+++ b/src/Forms/CustomForms.php
@@ -70,6 +70,10 @@ class CustomForms
                     ->label(__($field['label']))
                     ->placeholder(__($field['placeholder']))
                     ->seconds($field['seconds']);
+            } elseif {
+                 $fields[] = RichEditor::make($fieldKey)
+                    ->label(__($field['label']))
+                    ->toolbarButtons($field['toolbarButtons'] ?? []);
             }
         }
 

--- a/src/Forms/CustomForms.php
+++ b/src/Forms/CustomForms.php
@@ -70,7 +70,7 @@ class CustomForms
                     ->label(__($field['label']))
                     ->placeholder(__($field['placeholder']))
                     ->seconds($field['seconds']);
-            } elseif {
+            } elseif ($field['type'] === TypeFieldEnum::RichEditor->value) {
                  $fields[] = RichEditor::make($fieldKey)
                     ->label(__($field['label']))
                     ->toolbarButtons($field['toolbarButtons'] ?? []);


### PR DESCRIPTION
This pull request reintroduces an editor type that was added in #22 and integrate it into the custom forms functionality. This adds the `RichEditor` type to the `TypeFieldEnum` enumeration and it's corresponding implementation in the `CustomForms` class.

### New Editor Type:

* [`src/Enums/TypeFieldEnum.php`](diffhunk://#diff-77bff5434492890800c527eab519ee695bc59b0d38eacab6347dd311366b99abR16-R17): Added `RichEditor`  as a new case in the `TypeFieldEnum` enumeration.

### Custom Forms Integration:

* [`src/Forms/CustomForms.php`](diffhunk://#diff-c8a738d2d1430615dbbe07098ef0b941be29d47009810f71ae0564ea3536e157R7-R8): Imported `RichEditor` component.
* [`src/Forms/CustomForms.php`](diffhunk://#diff-c8a738d2d1430615dbbe07098ef0b941be29d47009810f71ae0564ea3536e157R55-R64): Updated the `get` method to handle `RichEditor`  type, including setting labels and toolbar buttons.

I am not sure why this was removed in #23 as no reason was stated, I needed the rich editor so I re added it.

Also I copied the PR message from #22 because we introduced the same changes